### PR TITLE
u-blox TXT support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 nom = "5"
 chrono = "0.4"
+arrayvec = "0.4"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -98,6 +98,7 @@ pub enum ParseResult {
     GSA(GsaData),
     VTG(VtgData),
     GLL(GllData),
+    TXT(TxtData),
     Unsupported(SentenceType),
 }
 
@@ -122,6 +123,7 @@ pub fn parse(xs: &[u8]) -> Result<ParseResult, String> {
             SentenceType::GSA => Ok(ParseResult::GSA(parse_gsa(&nmea_sentence)?)),
             SentenceType::VTG => Ok(ParseResult::VTG(parse_vtg(&nmea_sentence)?)),
             SentenceType::GLL => Ok(ParseResult::GLL(parse_gll(&nmea_sentence)?)),
+            SentenceType::TXT => Ok(ParseResult::TXT(parse_txt(&nmea_sentence)?)),
             msg_id => Ok(ParseResult::Unsupported(msg_id)),
         }
     } else {

--- a/src/sentences/mod.rs
+++ b/src/sentences/mod.rs
@@ -3,6 +3,7 @@ mod gll;
 mod gsa;
 mod gsv;
 mod rmc;
+mod txt;
 mod utils;
 mod vtg;
 
@@ -11,4 +12,5 @@ pub use gll::{parse_gll, GllData};
 pub use gsa::{parse_gsa, GsaData};
 pub use gsv::{parse_gsv, GsvData};
 pub use rmc::{parse_rmc, RmcData, RmcStatusOfFix};
+pub use txt::{parse_txt, TxtData};
 pub use vtg::{parse_vtg, VtgData};

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -1,9 +1,11 @@
+use arrayvec::ArrayString;
 use nom::character::complete::char;
-
 use nom::{bytes::complete::take_while, IResult};
 
 use super::utils::number;
 use crate::parse::NmeaSentence;
+
+const MAX_LEN: usize = 64;
 
 /// Parse TXT message from u-blox device
 ///
@@ -26,14 +28,32 @@ pub fn parse_txt(s: &NmeaSentence) -> Result<TxtData, String> {
                 kind.description().to_string()
             }
         })?;
-    Ok(ret)
+
+    let text_str = match std::str::from_utf8(ret.text) {
+        Ok(s) => s,
+        Err(_e) => {
+            return Err("txt: non-utf8 data".to_string());
+        }
+    };
+
+    let text = match ArrayString::from(text_str) {
+        Ok(s) => s,
+        Err(_e) => return Err("txt too long".to_string()),
+    };
+
+    Ok(TxtData {
+        count: ret.count,
+        seq: ret.seq,
+        text_ident: ret.text_ident,
+        text,
+    })
 }
 
 fn txt_str(s: &[u8]) -> IResult<&[u8], &[u8]> {
     take_while(|c| c != b',' && c != b'*')(s)
 }
 
-fn do_parse_txt(i: &[u8]) -> IResult<&[u8], TxtData> {
+fn do_parse_txt<'a>(i: &'a [u8]) -> IResult<&'a [u8], TxtData0<'a>> {
     let (i, count) = number::<u8>(i)?;
     let (i, _) = char(',')(i)?;
     let (i, seq) = number::<u8>(i)?;
@@ -44,11 +64,11 @@ fn do_parse_txt(i: &[u8]) -> IResult<&[u8], TxtData> {
 
     Ok((
         i,
-        TxtData {
+        TxtData0 {
             count,
             seq,
             text_ident,
-            text: std::str::from_utf8(text).unwrap().to_owned(),
+            text,
         },
     ))
 }
@@ -58,5 +78,49 @@ pub struct TxtData {
     pub count: u8,
     pub seq: u8,
     pub text_ident: u8,
-    pub text: String,
+    pub text: ArrayString<[u8; MAX_LEN]>,
+}
+
+struct TxtData0<'a> {
+    pub count: u8,
+    pub seq: u8,
+    pub text_ident: u8,
+    pub text: &'a [u8],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::parse::parse_nmea_sentence;
+
+    #[test]
+    fn smoke_test_parse_txt() {
+        let s = parse_nmea_sentence(b"$GNTXT,01,01,02,u-blox AG - www.u-blox.com*4E").unwrap();
+        let txt = parse_txt(&s).unwrap();
+        assert_eq!(
+            TxtData {
+                count: 1,
+                seq: 1,
+                text_ident: 2,
+                text: ArrayString::from("u-blox AG - www.u-blox.com").unwrap(),
+            },
+            txt
+        );
+
+        let gsa_examples = [
+            "$GPTXT,01,01,02,u-blox ag - www.u-blox.com*50",
+            "$GPTXT,01,01,02,HW  UBX-G70xx   00070000 FF7FFFFFo*69",
+            "$GPTXT,01,01,02,ROM CORE 1.00 (59842) Jun 27 2012 17:43:52*59",
+            "$GPTXT,01,01,02,PROTVER 14.00*1E",
+            "$GPTXT,01,01,02,ANTSUPERV=AC SD PDoS SR*20",
+            "$GPTXT,01,01,02,ANTSTATUS=OK*3B",
+            "$GPTXT,01,01,02,LLC FFFFFFFF-FFFFFFFF-FFFFFFFF-FFFFFFFF-FFFFFFFD*2C",
+        ];
+        for line in &gsa_examples {
+            println!("we parse line '{}'", line);
+            let s = parse_nmea_sentence(line.as_bytes()).unwrap();
+            parse_txt(&s).unwrap();
+        }
+    }
 }

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -1,0 +1,62 @@
+use nom::character::complete::char;
+
+use nom::{bytes::complete::take_while, IResult};
+
+use super::utils::number;
+use crate::parse::NmeaSentence;
+
+/// Parse TXT message from u-blox device
+///
+/// $GNTXT,01,01,02,u-blox AG - www.u-blox.com*4E
+/// 1   01  Total number of messages in this transmission, 01..99
+/// 2   01  Message number in this transmission, range 01..xx
+/// 3   02  Text identifier, u-blox GPS receivers specify the severity of the message with this number. 00 = ERROR, 01 = WARNING, 02 = NOTICE, 07 = USER
+/// 4   u-blox AG - www.u-blox.com  Any ASCII text
+/// *68        mandatory nmea_checksum
+pub fn parse_txt(s: &NmeaSentence) -> Result<TxtData, String> {
+    if s.message_id != b"TXT" {
+        return Err("TXT message should starts with $..TXT".into());
+    }
+
+    let ret = do_parse_txt(s.data)
+        .map(|(_, data)| data)
+        .map_err(|err| match err {
+            nom::Err::Incomplete(_) => "Incomplete nmea sentence".to_string(),
+            nom::Err::Error((_, kind)) | nom::Err::Failure((_, kind)) => {
+                kind.description().to_string()
+            }
+        })?;
+    Ok(ret)
+}
+
+fn txt_str(s: &[u8]) -> IResult<&[u8], &[u8]> {
+    take_while(|c| c != b',' && c != b'*')(s)
+}
+
+fn do_parse_txt(i: &[u8]) -> IResult<&[u8], TxtData> {
+    let (i, count) = number::<u8>(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, seq) = number::<u8>(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, text_ident) = number::<u8>(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, text) = txt_str(i)?;
+
+    Ok((
+        i,
+        TxtData {
+            count,
+            seq,
+            text_ident,
+            text: std::str::from_utf8(text).unwrap().to_owned(),
+        },
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TxtData {
+    pub count: u8,
+    pub seq: u8,
+    pub text_ident: u8,
+    pub text: String,
+}


### PR DESCRIPTION
Hi, I added a u-blox TXT message support.
Any feedback is welcome, especially on public interface: I used easiest way to expose a message, `Nmea::last_txt`, which returns latest TXT message, and user could pull a message with following code
```rust
match nmea.parse(&line) {
  Ok(nmea::SententType::TXT) => {
    let txt = nmea.last_txt();
  },
}
```
It exposes `TxtData` directly to public interface, and I'm not sure if it's okay.