### PR TITLE
exporting the new error system from the big yanp_merge PR, all tests …

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
 
 pub use crate::parse::{
     parse, GgaData, GllData, GsaData, GsvData, ParseResult, RmcData, RmcStatusOfFix, TxtData,
-    VtgData, NmeaError
+    VtgData, NmeaError, SENTENCE_MAX_LEN
 };
 use chrono::{NaiveDate, NaiveTime};
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -100,11 +100,10 @@ pub enum NmeaError<'a> {
     /// The provided input was not a proper UTF-8 string
     Utf8DecodingError,
     /// The checksum of the sentence was corrupt or wrong
-    /// First is the expected checksum, second is the found one
-    ChecksumMismatch(u8, u8),
+    ChecksumMismatch{ calculated: u8, found: u8},
     /// For some reason a sentence was passed to the wrong sentence specific parser, this error
     /// should never happen. First slice is the expected header, second is the found one
-    WrongSentenceHeader(&'a [u8], &'a [u8]),
+    WrongSentenceHeader{ expected: &'a [u8], found: &'a [u8]},
     /// The sentence could not be parsed because its format was invalid
     ParsingError(nom::Err<(&'a [u8], nom::error::ErrorKind)>),
     /// The sentence was too long to be parsed, our current limit is 102 characters
@@ -150,6 +149,6 @@ pub fn parse(xs: &[u8]) -> Result<ParseResult, NmeaError> {
             msg_id => Ok(ParseResult::Unsupported(msg_id)),
         }
     } else {
-        Err(NmeaError::ChecksumMismatch(calculated_checksum, nmea_sentence.checksum))
+        Err(NmeaError::ChecksumMismatch{calculated: calculated_checksum, found: nmea_sentence.checksum})
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -128,7 +128,7 @@ pub fn parse(xs: &[u8]) -> Result<ParseResult, NmeaError> {
     let nmea_sentence = parse_nmea_sentence(xs)?;
 
     if nmea_sentence.checksum == nmea_sentence.calc_checksum() {
-        match SentenceType::try_from(nmea_sentence.message_id)? {
+        match SentenceType::from_slice(nmea_sentence.message_id) {
             SentenceType::GGA => {
                 let data = parse_gga(nmea_sentence)?;
                 Ok(ParseResult::GGA(data))

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,6 +10,8 @@ use nom::IResult;
 pub use crate::sentences::*;
 use crate::SentenceType;
 
+pub const SENTENCE_MAX_LEN: usize = 102;
+
 pub struct NmeaSentence<'a> {
     pub talker_id: &'a [u8],
     pub message_id: &'a [u8],
@@ -77,7 +79,7 @@ pub fn parse_nmea_sentence<'a>(sentence: &'a [u8]) -> std::result::Result<NmeaSe
      * The current hog champion is the Skytraq S2525F8 which emits
      * a 100-character PSTI message.
      */
-    if sentence.len() > 102 {
+    if sentence.len() > SENTENCE_MAX_LEN {
         Err(NmeaError::SentenceLength(sentence.len()))
     } else {
         Ok(do_parse_nmea_sentence(sentence)?.1)
@@ -106,7 +108,7 @@ pub enum NmeaError<'a> {
     WrongSentenceHeader{ expected: &'a [u8], found: &'a [u8]},
     /// The sentence could not be parsed because its format was invalid
     ParsingError(nom::Err<(&'a [u8], nom::error::ErrorKind)>),
-    /// The sentence was too long to be parsed, our current limit is 102 characters
+    /// The sentence was too long to be parsed, our current limit is `SENTENCE_MAX_LEN` characters
     SentenceLength(usize),
     /// The type of a GSV sentence was not a valid Gnss type
     InvalidGnssType,

--- a/src/sentences/gga.rs
+++ b/src/sentences/gga.rs
@@ -77,7 +77,7 @@ fn do_parse_gga(i: &[u8]) -> IResult<&[u8], GgaData> {
 /// (empty field) DGPS station ID number (0000-1023)
 pub fn parse_gga(sentence: NmeaSentence) -> Result<GgaData, NmeaError> {
     if sentence.message_id != b"GGA" {
-        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"GGA"))
+        Err(NmeaError::WrongSentenceHeader{expected: b"GGA", found: sentence.message_id})
     } else {
         Ok(do_parse_gga(sentence.data)?.1)
     }

--- a/src/sentences/gll.rs
+++ b/src/sentences/gll.rs
@@ -24,7 +24,7 @@ use crate::{NmeaError, sentences::utils::{do_parse_lat_lon, parse_hms}};
 /// | 9     | *xx         | Check sum
 pub fn parse_gll(sentence: NmeaSentence) -> Result<GllData, NmeaError> {
     if sentence.message_id != b"GLL" {
-        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"GLL"))
+        Err(NmeaError::WrongSentenceHeader{expected: b"GLL", found: sentence.message_id})
     } else {
         Ok(do_parse_gll(sentence.data)?.1)
     }

--- a/src/sentences/gsa.rs
+++ b/src/sentences/gsa.rs
@@ -130,7 +130,7 @@ fn do_parse_gsa(i: &[u8]) -> IResult<&[u8], GsaData> {
 /// Alarmingly, it's possible this error may be generic to SiRFstarIII
 pub fn parse_gsa(sentence: NmeaSentence) -> Result<GsaData, NmeaError> {
     if sentence.message_id != b"GSA" {
-        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"GSA"))
+        Err(NmeaError::WrongSentenceHeader{expected: b"GSA", found: sentence.message_id})
     } else {
         Ok(do_parse_gsa(sentence.data)?.1)
     }

--- a/src/sentences/gsv.rs
+++ b/src/sentences/gsv.rs
@@ -84,16 +84,16 @@ fn do_parse_gsv(i: &[u8]) -> IResult<&[u8], GsvData> {
 /// only.  Usage is inconsistent.
 pub fn parse_gsv(sentence: NmeaSentence) -> Result<GsvData, NmeaError> {
     if sentence.message_id != b"GSV" {
-        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"GSV"))
+        Err(NmeaError::WrongSentenceHeader{expected: b"GSV", found: sentence.message_id})
     } else {
         let gnss_type = match sentence.talker_id {
             b"GP" => GnssType::Gps,
             b"GL" => GnssType::Glonass,
             _ => {
-                return Err(NmeaError::WrongSentenceHeader(
-                    sentence.message_id,
-                    b"GP|GL",
-                ))
+                return Err(NmeaError::WrongSentenceHeader{
+                    expected: b"GP|GL",
+                    found: sentence.message_id,
+                })
             }
         };
         let mut res = do_parse_gsv(sentence.data)?.1;

--- a/src/sentences/gsv.rs
+++ b/src/sentences/gsv.rs
@@ -4,7 +4,7 @@ use nom::IResult;
 
 use crate::parse::NmeaSentence;
 use crate::sentences::utils::number;
-use crate::{GnssType, Satellite};
+use crate::{GnssType, Satellite, NmeaError};
 
 pub struct GsvData {
     pub gnss_type: GnssType,
@@ -82,31 +82,29 @@ fn do_parse_gsv(i: &[u8]) -> IResult<&[u8], GsvData> {
 /// GL may be (incorrectly) used when GSVs are mixed containing
 /// GLONASS, GN may be (incorrectly) used when GSVs contain GLONASS
 /// only.  Usage is inconsistent.
-pub fn parse_gsv(sentence: &NmeaSentence) -> Result<GsvData, String> {
+pub fn parse_gsv(sentence: NmeaSentence) -> Result<GsvData, NmeaError> {
     if sentence.message_id != b"GSV" {
-        return Err("GSV sentence not starts with $..GSV".into());
-    }
-    let gnss_type = match sentence.talker_id {
-        b"GP" => GnssType::Gps,
-        b"GL" => GnssType::Glonass,
-        _ => return Err("Unknown GNSS type in GSV sentence".into()),
-    };
-    //    println!("parse: '{}'", str::from_utf8(sentence.data).unwrap());
-    let mut res: GsvData = do_parse_gsv(sentence.data)
-        .map_err(|err| match err {
-            nom::Err::Incomplete(_) => "Incomplete nmea sentence".to_string(),
-            nom::Err::Error((_, kind)) | nom::Err::Failure((_, kind)) => {
-                kind.description().to_string()
+        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"GSV"))
+    } else {
+        let gnss_type = match sentence.talker_id {
+            b"GP" => GnssType::Gps,
+            b"GL" => GnssType::Glonass,
+            _ => {
+                return Err(NmeaError::WrongSentenceHeader(
+                    sentence.message_id,
+                    b"GP|GL",
+                ))
             }
-        })?
-        .1;
-    res.gnss_type = gnss_type.clone();
-    for sat in &mut res.sats_info {
-        if let Some(v) = (*sat).as_mut() {
-            v.gnss_type = gnss_type.clone();
+        };
+        let mut res = do_parse_gsv(sentence.data)?.1;
+        res.gnss_type = gnss_type;
+        for sat in &mut res.sats_info {
+            if let Some(v) = (*sat).as_mut() {
+                v.gnss_type = gnss_type;
+            }
         }
+        Ok(res)
     }
-    Ok(res)
 }
 
 #[cfg(test)]
@@ -115,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_parse_gsv_full() {
-        let data = parse_gsv(&NmeaSentence {
+        let data = parse_gsv(NmeaSentence {
             talker_id: b"GP",
             message_id: b"GSV",
             data: b"2,1,08,01,,083,46,02,17,308,,12,07,344,39,14,22,228,",
@@ -167,7 +165,7 @@ mod tests {
             }
         );
 
-        let data = parse_gsv(&NmeaSentence {
+        let data = parse_gsv(NmeaSentence {
             talker_id: b"GL",
             message_id: b"GSV",
             data: b"3,3,10,72,40,075,43,87,00,000,",

--- a/src/sentences/rmc.rs
+++ b/src/sentences/rmc.rs
@@ -78,7 +78,7 @@ fn do_parse_rmc(i: &[u8]) -> IResult<&[u8], RmcData> {
 /// SiRF chipsets don't return either Mode Indicator or magnetic variation.
 pub fn parse_rmc(sentence: NmeaSentence) -> Result<RmcData, NmeaError> {
     if sentence.message_id != b"RMC" {
-        Err(NmeaError::WrongSentenceHeader(b"RMC", sentence.message_id))
+        Err(NmeaError::WrongSentenceHeader{expected: b"RMC", found: sentence.message_id})
     } else {
         Ok(do_parse_rmc(sentence.data)?.1)
     }

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -3,7 +3,7 @@ use nom::character::complete::char;
 use nom::{bytes::complete::take_while, IResult};
 
 use super::utils::number;
-use crate::parse::NmeaSentence;
+use crate::{NmeaError, parse::NmeaSentence};
 
 const MAX_LEN: usize = 64;
 
@@ -15,31 +15,16 @@ const MAX_LEN: usize = 64;
 /// 3   02  Text identifier, u-blox GPS receivers specify the severity of the message with this number. 00 = ERROR, 01 = WARNING, 02 = NOTICE, 07 = USER
 /// 4   u-blox AG - www.u-blox.com  Any ASCII text
 /// *68        mandatory nmea_checksum
-pub fn parse_txt(s: &NmeaSentence) -> Result<TxtData, String> {
+pub fn parse_txt(s: NmeaSentence) -> Result<TxtData, NmeaError> {
     if s.message_id != b"TXT" {
-        return Err("TXT message should starts with $..TXT".into());
+        return Err(NmeaError::WrongSentenceHeader(b"TXT", s.message_id));
     }
 
-    let ret = do_parse_txt(s.data)
-        .map(|(_, data)| data)
-        .map_err(|err| match err {
-            nom::Err::Incomplete(_) => "Incomplete nmea sentence".to_string(),
-            nom::Err::Error((_, kind)) | nom::Err::Failure((_, kind)) => {
-                kind.description().to_string()
-            }
-        })?;
+    let ret = do_parse_txt(s.data).map_err(|err| NmeaError::ParsingError(err))?.1;
 
-    let text_str = match std::str::from_utf8(ret.text) {
-        Ok(s) => s,
-        Err(_e) => {
-            return Err("txt: non-utf8 data".to_string());
-        }
-    };
+    let text_str = std::str::from_utf8(ret.text).map_err(|_e| NmeaError::Utf8DecodingError)?;
 
-    let text = match ArrayString::from(text_str) {
-        Ok(s) => s,
-        Err(_e) => return Err("txt too long".to_string()),
-    };
+    let text = ArrayString::from(text_str).map_err(|_e| NmeaError::SentenceLength(text_str.len()))?;
 
     Ok(TxtData {
         count: ret.count,
@@ -97,7 +82,7 @@ mod tests {
     #[test]
     fn smoke_test_parse_txt() {
         let s = parse_nmea_sentence(b"$GNTXT,01,01,02,u-blox AG - www.u-blox.com*4E").unwrap();
-        let txt = parse_txt(&s).unwrap();
+        let txt = parse_txt(s).unwrap();
         assert_eq!(
             TxtData {
                 count: 1,
@@ -120,7 +105,7 @@ mod tests {
         for line in &gsa_examples {
             println!("we parse line '{}'", line);
             let s = parse_nmea_sentence(line.as_bytes()).unwrap();
-            parse_txt(&s).unwrap();
+            parse_txt(s).unwrap();
         }
     }
 }

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -17,7 +17,7 @@ const MAX_LEN: usize = 64;
 /// *68        mandatory nmea_checksum
 pub fn parse_txt(s: NmeaSentence) -> Result<TxtData, NmeaError> {
     if s.message_id != b"TXT" {
-        return Err(NmeaError::WrongSentenceHeader(b"TXT", s.message_id));
+        return Err(NmeaError::WrongSentenceHeader{expected: b"TXT", found: s.message_id});
     }
 
     let ret = do_parse_txt(s.data).map_err(|err| NmeaError::ParsingError(err))?.1;

--- a/src/sentences/vtg.rs
+++ b/src/sentences/vtg.rs
@@ -73,7 +73,7 @@ fn do_parse_vtg(i: &[u8]) -> IResult<&[u8], VtgData> {
 /// x.x,K = Speed, Km/hr
 pub fn parse_vtg(sentence: NmeaSentence) -> Result<VtgData, NmeaError> {
     if sentence.message_id != b"VTG" {
-        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"VTG"))
+        Err(NmeaError::WrongSentenceHeader{expected: b"VTG", found: sentence.message_id})
     } else {
         Ok(do_parse_vtg(sentence.data)?.1)
     }

--- a/src/sentences/vtg.rs
+++ b/src/sentences/vtg.rs
@@ -3,7 +3,7 @@ use nom::combinator::opt;
 use nom::number::complete::float;
 use nom::IResult;
 
-use crate::parse::NmeaSentence;
+use crate::{NmeaError, parse::NmeaSentence};
 
 #[derive(Debug, PartialEq)]
 pub struct VtgData {
@@ -71,55 +71,48 @@ fn do_parse_vtg(i: &[u8]) -> IResult<&[u8], VtgData> {
 /// x.x,M = Track, degrees Magnetic
 /// x.x,N = Speed, knots
 /// x.x,K = Speed, Km/hr
-pub fn parse_vtg(s: &NmeaSentence) -> Result<VtgData, String> {
-    if s.message_id != b"VTG" {
-        return Err("VTG message should starts with $..VTG".into());
+pub fn parse_vtg(sentence: NmeaSentence) -> Result<VtgData, NmeaError> {
+    if sentence.message_id != b"VTG" {
+        Err(NmeaError::WrongSentenceHeader(sentence.message_id, b"VTG"))
+    } else {
+        Ok(do_parse_vtg(sentence.data)?.1)
     }
-    let ret: VtgData = do_parse_vtg(s.data)
-        .map(|(_, data)| data)
-        .map_err(|err| match err {
-            nom::Err::Incomplete(_) => "Incomplete nmea sentence".to_string(),
-            nom::Err::Error((_, kind)) | nom::Err::Failure((_, kind)) => {
-                kind.description().to_string()
-            }
-        })?;
-    Ok(ret)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::parse::parse_nmea_sentence;
+    use crate::parse::{parse_nmea_sentence, NmeaError};
+
+    fn run_parse_vtg(line: &[u8]) -> Result<VtgData, NmeaError> {
+        let s = parse_nmea_sentence(line).expect("VTG sentence initial parse failed");
+        assert_eq!(s.checksum, s.calc_checksum());
+        parse_vtg(s)
+    }
 
     #[test]
     fn test_parse_vtg() {
-        let run_parse_vtg = |line: &str| -> Result<VtgData, String> {
-            let s =
-                parse_nmea_sentence(line.as_bytes()).expect("VTG sentence initial parse failed");
-            assert_eq!(s.checksum, s.calc_checksum());
-            parse_vtg(&s)
-        };
         assert_eq!(
             VtgData {
                 true_course: None,
                 speed_over_ground: None,
             },
-            run_parse_vtg("$GPVTG,,T,,M,,N,,K,N*2C").unwrap()
+            run_parse_vtg(b"$GPVTG,,T,,M,,N,,K,N*2C").unwrap()
         );
         assert_eq!(
             VtgData {
                 true_course: Some(360.),
                 speed_over_ground: Some(0.),
             },
-            run_parse_vtg("$GPVTG,360.0,T,348.7,M,000.0,N,000.0,K*43").unwrap()
+            run_parse_vtg(b"$GPVTG,360.0,T,348.7,M,000.0,N,000.0,K*43").unwrap()
         );
         assert_eq!(
             VtgData {
                 true_course: Some(54.7),
                 speed_over_ground: Some(5.5),
             },
-            run_parse_vtg("$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*48").unwrap()
+            run_parse_vtg(b"$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*48").unwrap()
         );
     }
 }

--- a/tests/file_log_parser.rs
+++ b/tests/file_log_parser.rs
@@ -19,7 +19,7 @@ fn process_file(n: &Path) -> Result<Vec<String>, String> {
             .map_err(|s| format!("{} at line {}", s, num + 1))?;
         let parse_res = nmea
             .parse(&line)
-            .map_err(|s| format!("{} at line {}", s, num + 1))?;
+            .map_err(|s| format!("{:?} at line {}", s, num + 1))?;
         ret.push(format!("{:?}", parse_res));
     }
     Ok(ret)


### PR DESCRIPTION
This introduces a new, type instead of String based, error system, bringing some changes to internal APIs as well as (of course) returning NmeaError's instead of String's at the outer API's.