### PR TITLE
use core when possible instead of std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@
 mod parse;
 mod sentences;
 
-use std::{
-    collections::{HashMap, HashSet},
+use std::collections::{HashMap, HashSet};
+use core::{
     iter::Iterator,
-    {fmt, mem, str},
+    fmt, mem, str
 };
 
 pub use crate::parse::{

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use std::str;
+use core::str;
 
 use nom::bytes::complete::{take, take_until};
 use nom::character::complete::char;
@@ -35,7 +35,7 @@ pub fn checksum<'a, I: Iterator<Item = &'a u8>>(bytes: I) -> u8 {
     bytes.fold(0, |c, x| c ^ *x)
 }
 
-fn parse_hex(data: &[u8]) -> std::result::Result<u8, &'static str> {
+fn parse_hex(data: &[u8]) -> core::result::Result<u8, &'static str> {
     u8::from_str_radix(unsafe { str::from_utf8_unchecked(data) }, 16)
         .map_err(|_| "Failed to parse checksum as hex number")
 }
@@ -62,7 +62,7 @@ fn do_parse_nmea_sentence(i: &[u8]) -> IResult<&[u8], NmeaSentence> {
     ))
 }
 
-pub fn parse_nmea_sentence<'a>(sentence: &'a [u8]) -> std::result::Result<NmeaSentence, NmeaError<'a>> {
+pub fn parse_nmea_sentence<'a>(sentence: &'a [u8]) -> core::result::Result<NmeaSentence, NmeaError<'a>> {
     /*
      * From gpsd:
      * We've had reports that on the Garmin GPS-10 the device sometimes

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -22,7 +22,7 @@ pub fn parse_txt(s: NmeaSentence) -> Result<TxtData, NmeaError> {
 
     let ret = do_parse_txt(s.data).map_err(|err| NmeaError::ParsingError(err))?.1;
 
-    let text_str = std::str::from_utf8(ret.text).map_err(|_e| NmeaError::Utf8DecodingError)?;
+    let text_str = core::str::from_utf8(ret.text).map_err(|_e| NmeaError::Utf8DecodingError)?;
 
     let text = ArrayString::from(text_str).map_err(|_e| NmeaError::SentenceLength(text_str.len()))?;
 

--- a/src/sentences/utils.rs
+++ b/src/sentences/utils.rs
@@ -1,4 +1,4 @@
-use std::str;
+use core::str;
 
 use chrono::{NaiveDate, NaiveTime};
 use nom::branch::alt;
@@ -16,7 +16,7 @@ pub(crate) fn parse_hms(i: &[u8]) -> IResult<&[u8], NaiveTime> {
             map_res(take(2usize), parse_num::<u32>),
             map_parser(take_until(","), double),
         )),
-        |(hour, minutes, sec)| -> std::result::Result<NaiveTime, &'static str> {
+        |(hour, minutes, sec)| -> core::result::Result<NaiveTime, &'static str> {
             if sec.is_sign_negative() {
                 return Err("Invalid time: second is negative");
             }
@@ -86,19 +86,19 @@ pub(crate) fn parse_date(i: &[u8]) -> IResult<&[u8], NaiveDate> {
     )(i)
 }
 
-pub(crate) fn parse_num<I: std::str::FromStr>(data: &[u8]) -> std::result::Result<I, &'static str> {
+pub(crate) fn parse_num<I: str::FromStr>(data: &[u8]) -> core::result::Result<I, &'static str> {
     //    println!("parse num {}", unsafe { str::from_utf8_unchecked(data) });
     str::parse::<I>(unsafe { str::from_utf8_unchecked(data) }).map_err(|_| "parse of number failed")
 }
 
 pub(crate) fn parse_float_num<T: str::FromStr>(
     input: &[u8],
-) -> std::result::Result<T, &'static str> {
+) -> core::result::Result<T, &'static str> {
     let s = str::from_utf8(input).map_err(|_| "invalid float number")?;
     str::parse::<T>(s).map_err(|_| "parse of float number failed")
 }
 
-pub(crate) fn number<T: std::str::FromStr>(i: &[u8]) -> IResult<&[u8], T> {
+pub(crate) fn number<T: str::FromStr>(i: &[u8]) -> IResult<&[u8], T> {
     map_res(digit1, parse_num)(i)
 }
 


### PR DESCRIPTION
As a first step of the no_std compatability we can just use core instead of std when possible since lots of std is actually just core re-exports.