### PR TITLE
Heapless

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,3 @@
 Felix Obenhuber <felix@obenhuber.de>
 Evgeniy A. Dushistov <dushistov@mail.ru>
+Henrik Böving <hargonix@gmail.com>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 nom = "5"
 chrono = "0.4"
-arrayvec = "0.5"
+heapless = "0.5"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ edition = "2018"
 nom = "5"
 chrono = "0.4"
 heapless = "0.5"
-num-traits = "0.2"
-num-derive = "0.3"
 hash32 = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ edition = "2018"
 [dependencies]
 nom = "5"
 chrono = "0.4"
-heapless = "0.5"
-hash32 = "0.1"
+arrayvec = "0.5"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "nmea"
 version = "0.0.9"
-authors = ["Felix Obenhuber <felix@obenhuber.de>", "Evgeniy A. Dushistov <dushistov@mail.ru>"]
+authors = [
+    "Felix Obenhuber <felix@obenhuber.de>",
+    "Evgeniy A. Dushistov <dushistov@mail.ru>",
+    "Henrik Böving <hargonix@gmail.com>"
+]
 description = "Simple NMEA 0183 parser"
 license = "Apache-2.0"
 keywords = ["NMEA", "gps", "glonass", "coordinate", "position"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ edition = "2018"
 nom = "5"
 chrono = "0.4"
 heapless = "0.5"
+num-traits = "0.2"
+num-derive = "0.3"
+hash32 = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,12 @@
 // limitations under the License.
 //
 
-#[macro_use]
-extern crate num_derive;
-
 mod parse;
 mod sentences;
 
 use core::{fmt, iter::Iterator, mem};
 use heapless::consts::*;
 use heapless::{FnvIndexMap, FnvIndexSet};
-use num_traits::ToPrimitive;
 
 pub use crate::parse::{
     parse, GgaData, GllData, GsaData, GsvData, NmeaError, ParseResult, RmcData, RmcStatusOfFix,
@@ -119,7 +115,7 @@ impl hash32::Hash for SentenceType {
     where
         H: hash32::Hasher,
     {
-        self.to_u32().unwrap().hash(state);
+        (*self as u32).hash(state);
     }
 }
 
@@ -128,7 +124,7 @@ impl hash32::Hash for GnssType {
     where
         H: hash32::Hasher,
     {
-        self.to_u32().unwrap().hash(state);
+        (*self as u32).hash(state);
     }
 }
 
@@ -550,7 +546,8 @@ macro_rules! define_sentence_type_enum {
 	enum $Name:ident { $($Variant:ident),* $(,)* }
     ) => {
 	$(#[$outer])*
-        #[derive(PartialEq, Debug, Hash, Eq, Copy, Clone, ToPrimitive)]
+        #[derive(PartialEq, Debug, Hash, Eq, Copy, Clone)]
+        #[repr(u32)]
         pub enum $Name {
             None,
             $($Variant),*,
@@ -723,7 +720,8 @@ pub enum FixType {
 }
 
 /// GNSS type
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, ToPrimitive)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[repr(u32)]
 pub enum GnssType {
     Galileo,
     Gps,


### PR DESCRIPTION
Migrate HashMap, HashSet and String to heapless 
The HashMap and Set limits inside the Nmea struct are chosen so they fit the
amount of sentences that are parsable right now, theoretically we would
need to set them to 128 if we actually want to avoid any panicking since
there are only 99 NMEA 0138 sentence types we are aware of (128 because
the capacities have to be a power of 2).

If someone thinks we should change it so absolutely no panicking is logically possible I can turn the limits (and by that also memory usage :/) up.
