### PR TITLE
Implement Display+Error for NmeaError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ arrayvec = "0.5"
 [dev-dependencies]
 quickcheck = "0.9"
 approx = "0.3"
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
Hey! 👋 

I'm trying to use this crate and have the errors propagated up. It looks like `Error` is not implemented for `NmeaError`, so here is a PR to fix that.

We implement Display unconditionally for `NmeaError`, and `std::error::Error`when working in a `std` environment.

To distinguish between `no_std` and `std` we add an optional but enabled by default `std` feature. As far as I can tell, rust doesn't yet have a proper way to do this...