### PR TITLE
Fix parsing and expose PosSysIndicator in GLL Messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod sentences;
 
 pub use crate::parse::{
     parse, BwcData, GgaData, GllData, GsaData, GsvData, NmeaError, ParseResult, RmcData,
-    RmcStatusOfFix, TxtData, VtgData, SENTENCE_MAX_LEN,
+    RmcStatusOfFix, PosSystemIndicator, TxtData, VtgData, SENTENCE_MAX_LEN,
 };
 use chrono::{NaiveDate, NaiveTime};
 use core::{fmt, iter::Iterator, mem, ops::BitOr};

--- a/src/sentences/mod.rs
+++ b/src/sentences/mod.rs
@@ -10,7 +10,7 @@ mod vtg;
 
 pub use bwc::{parse_bwc, BwcData};
 pub use gga::{parse_gga, GgaData};
-pub use gll::{parse_gll, GllData};
+pub use gll::{parse_gll, GllData, PosSystemIndicator};
 pub use gsa::{parse_gsa, GsaData};
 pub use gsv::{parse_gsv, GsvData};
 pub use rmc::{parse_rmc, RmcData, RmcStatusOfFix};


### PR DESCRIPTION
Due to a bug in parsing we were never actually filling the PosSysIndicator in GLL Messages. We also never exposed this type outside the crate, this PR fixes that.