### PR TITLE
Dual license with MIT and Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "AeroRust <aerospace.rust@gmail.com>"
 ]
 description = "Simple NMEA 0183 parser"
-license = "Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["NMEA", "gps", "glonass", "coordinate", "position"]
 categories = ["parser-implementations", "no-std", "embedded"]
 repository = "https://github.com/AeroRust/nmea"
@@ -38,6 +38,7 @@ quickcheck = { version = "1.0.3", default-features = false }
 approx = "0.5.1"
 pretty_assertions = "1"
 doc-comment = "0.3"
+once_cell = "1"
 
 [features]
 default = ["std"]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,5 +1,5 @@
 Copyright 2016 Felix Obenhuber
-Copyright 2020 ÄroRust 
+Copyright 2020 ÄroRust
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,26 @@
+Copyright 2016 Felix Obenhuber
+Copyright 2020 ÄroRust
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 NMEA 0183 sentence parser for Rust.
 
 Supported sentences:
-- BWC
+- BWC (supported by `parse()`, but not by `Nmea::parse()`)
 - GGA
 - GLL
 - GNS
@@ -68,12 +68,14 @@ The Minimum supported Rust version (or MSRV) is **1.56**.
 
 We use `#![deny(unsafe_code)]` for a fully `unsafe`-free crate.
 
+
 ## License
 
-This project is licensed under the [Apache-2.0](./LICENSE.txt).
+Licensed under either of [Apache License, Version 2.0](./LICENSE-APACHE)
+or [MIT license](./LICENSE-MIT) at your option.
 
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the project by you, shall be licensed as Apache-2.0,
-without any additional terms or conditions.
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
@Dushistov  @flxo could you please take a look at the dual licensing and say if you're ok with it?
I've kept the copyright to MIT & Apache and Apache-2.0 is the default license for contributing to the crate.