### PR TITLE
Use criterion for benchmarks and update bod parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,21 +26,21 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-arrayvec = {version = "0.7.2", default-features = false}
-chrono = {version = "0.4.19", default-features = false}
+arrayvec = { version = "0.7.2", default-features = false }
+chrono = { version = "0.4.19", default-features = false }
 heapless = "0.7.15"
-nom = {version = "7.1.1", default-features = false}
+nom = { version = "7.1.1", default-features = false }
 
 # we include num-traits only when `std` is not enabled
 # because of `fract()` and `trunc()` methods
-num-traits = {version = "0.2", default-features = false}
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 approx = "0.5.1"
 doc-comment = "0.3"
 pretty_assertions = "1"
-quickcheck = {version = "1.0.3", default-features = false}
-criterion = "0.4.0"
+quickcheck = { version = "1.0.3", default-features = false }
+criterion = "0.3"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,12 @@ approx = "0.5.1"
 doc-comment = "0.3"
 pretty_assertions = "1"
 quickcheck = {version = "1.0.3", default-features = false}
+criterion = "0.4.0"
 
 [features]
 default = ["std"]
 std = ["nom/std", "chrono/std", "arrayvec/std"]
+
+[[bench]]
+name = "gsv_parser"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,9 @@ default = ["std"]
 std = ["nom/std", "chrono/std", "arrayvec/std"]
 
 [[bench]]
+name = "nom_parsing"
+harness = false
+
+[[bench]]
 name = "gsv_parser"
 harness = false

--- a/benches/gsv_parser.rs
+++ b/benches/gsv_parser.rs
@@ -1,23 +1,18 @@
-#![feature(test)]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-extern crate test;
+use nmea::{Nmea, SentenceType};
 
-#[cfg(test)]
-mod tests {
-    use nmea::{Nmea, SentenceType};
-    use test::{black_box, Bencher};
+fn bench_gsv_parser(c: &mut Criterion) {
+    let input = [
+        "$GPGSV,3,1,12,01,49,196,41,03,71,278,32,06,02,323,27,11,21,196,39*72",
+        "$GPGSV,3,2,12,14,39,063,33,17,21,292,30,19,20,310,31,22,82,181,36*73",
+        "$GPGSV,3,3,12,23,34,232,42,25,11,045,33,31,45,092,38,32,14,061,39*75",
+        "$GLGSV,3,1,10,74,40,078,43,66,23,275,31,82,10,347,36,73,15,015,38*6B",
+        "$GLGSV,3,2,10,75,19,135,36,65,76,333,31,88,32,233,33,81,40,302,38*6A",
+        "$GLGSV,3,3,10,72,40,075,43,87,00,000,*6F",
+    ];
 
-    #[bench]
-    fn bench_gsv_parser(b: &mut Bencher) {
-        let input = [
-            "$GPGSV,3,1,12,01,49,196,41,03,71,278,32,06,02,323,27,11,21,196,39*72",
-            "$GPGSV,3,2,12,14,39,063,33,17,21,292,30,19,20,310,31,22,82,181,36*73",
-            "$GPGSV,3,3,12,23,34,232,42,25,11,045,33,31,45,092,38,32,14,061,39*75",
-            "$GLGSV,3,1,10,74,40,078,43,66,23,275,31,82,10,347,36,73,15,015,38*6B",
-            "$GLGSV,3,2,10,75,19,135,36,65,76,333,31,88,32,233,33,81,40,302,38*6A",
-            "$GLGSV,3,3,10,72,40,075,43,87,00,000,*6F",
-        ];
-
+    c.bench_function("gsv parser", |b| {
         b.iter(|| {
             let mut nmea = Nmea::default();
             for line in &input {
@@ -25,5 +20,8 @@ mod tests {
                 assert_eq!(pack_type, SentenceType::GSV);
             }
         });
-    }
+    });
 }
+
+criterion_group!(benches, bench_gsv_parser);
+criterion_main!(benches);

--- a/benches/nom_parsing.rs
+++ b/benches/nom_parsing.rs
@@ -16,6 +16,10 @@ struct MockBodData<'a> {
 
 static BOD_SENTENCE: &str = "097.0,T,103.2,M,POINTB,POINTA";
 fn parsing_combinators_benchmark(c: &mut Criterion) {
+    /*
+    This benchmark was created to compare parsing strategies for handling commas during
+    parsing of sentences.
+     */
     let mut bench_group = c.benchmark_group("comma-separated parsing");
 
     bench_group.bench_function("let (i, ...) = preceded(char(','), ...)(i)?", |b| {

--- a/benches/nom_parsing.rs
+++ b/benches/nom_parsing.rs
@@ -1,0 +1,117 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use nmea::Error;
+use nom::{
+    bytes::complete::*, character::complete::*, combinator::*, number::complete::*,
+    sequence::preceded,
+};
+
+#[allow(dead_code)]
+struct MockBodData<'a> {
+    bearing_true: Option<f32>,
+    bearing_magnetic: Option<f32>,
+    to_waypoint: Option<&'a str>,
+    from_waypoint: Option<&'a str>,
+}
+
+static BOD_SENTENCE: &str = "097.0,T,103.2,M,POINTB,POINTA";
+fn parsing_combinators_benchmark(c: &mut Criterion) {
+    let mut bench_group = c.benchmark_group("comma-separated parsing");
+
+    bench_group.bench_function("let (i, ...) = preceded(char(','), ...)(i)?", |b| {
+        b.iter(|| {
+            _ = parse_bod_with_preceded(black_box(BOD_SENTENCE)).unwrap();
+        })
+    });
+
+    bench_group.bench_function("let (i, _) = char(',')(i)?", |b| {
+        b.iter(|| {
+            _ = parse_bod_discard_comma(black_box(BOD_SENTENCE)).unwrap();
+        })
+    });
+
+    let test_2 = "something,another";
+
+    bench_group.bench_function("lite bench: preceded(char(','),...)", |b| {
+        b.iter(|| {
+            let (i, something) = take_until::<_, _, ()>(",")(test_2).unwrap();
+            let (_, another) = preceded(char::<_, ()>(','), rest)(i).unwrap();
+            black_box((something, another))
+        })
+    });
+
+    bench_group.bench_function("lite bench: char(',')", |b| {
+        b.iter(|| {
+            let (i, something) = take_until::<_, _, ()>(",")(test_2).unwrap();
+            let (i, _) = char::<_, ()>(',')(i).unwrap();
+            let (_, another) = rest::<_, ()>(i).unwrap();
+            black_box((something, another))
+        })
+    });
+}
+
+fn parse_bod_discard_comma(i: &str) -> Result<MockBodData, Error> {
+    // 1. Bearing Degrees, True
+    let (i, bearing_true) = opt(map_parser(take_until(","), float))(i)?;
+    let (i, _) = char(',')(i)?;
+
+    // 2. T = True
+    let (i, _) = char('T')(i)?;
+    let (i, _) = char(',')(i)?;
+
+    // 3. Bearing Degrees, Magnetic
+    let (i, bearing_magnetic) = opt(float)(i)?;
+    let (i, _) = char(',')(i)?;
+
+    // 4. M = Magnetic
+    let (i, _) = char('M')(i)?;
+    let (i, _) = char(',')(i)?;
+
+    // 5. Destination Waypoint
+    let (i, to_waypoint) = opt(is_not(",*"))(i)?;
+    let (i, _) = char(',')(i)?;
+
+    // 6. origin Waypoint
+    let from_waypoint = opt(is_not("*"))(i)?.1;
+
+    // 7. Checksum
+
+    Ok(MockBodData {
+        bearing_true,
+        bearing_magnetic,
+        to_waypoint,
+        from_waypoint,
+    })
+}
+
+fn parse_bod_with_preceded(i: &str) -> Result<MockBodData, Error> {
+    // 1. Bearing Degrees, True
+    let (i, bearing_true) = opt(map_parser(take_until(","), float))(i)?;
+
+    // 2. T = True
+    let (i, _) = preceded(char(','), char('T'))(i)?;
+
+    // 3. Bearing Degrees, Magnetic
+    let (i, bearing_magnetic) = preceded(char(','), opt(float))(i)?;
+
+    // 4. M = Magnetic
+    let (i, _) = preceded(char(','), char('M'))(i)?;
+
+    // 5. Destination Waypoint
+    let (i, to_waypoint) = preceded(char(','), opt(is_not(",*")))(i)?;
+
+    // 6. origin Waypoint
+    let from_waypoint = opt(preceded(char(','), is_not("*")))(i)?.1;
+
+    // 7. Checksum
+
+    Ok(MockBodData {
+        bearing_true,
+        bearing_magnetic,
+        to_waypoint,
+        from_waypoint,
+    })
+}
+
+criterion_group!(benches, parsing_combinators_benchmark);
+criterion_main!(benches);

--- a/src/sentences/bod.rs
+++ b/src/sentences/bod.rs
@@ -38,18 +38,22 @@ pub struct BodData {
 fn do_parse_bod(i: &str) -> Result<BodData, Error> {
     // 1. Bearing Degrees, True
     let (i, bearing_true) = opt(map_parser(take_until(","), float))(i)?;
+    let (i, _) = char(',')(i)?;
 
     // 2. T = True
-    let (i, _) = preceded(char(','), char('T'))(i)?;
+    let (i, _) = char('T')(i)?;
+    let (i, _) = char(',')(i)?;
 
     // 3. Bearing Degrees, Magnetic
-    let (i, bearing_magnetic) = preceded(char(','), opt(float))(i)?;
+    let (i, bearing_magnetic) = opt(float)(i)?;
+    let (i, _) = char(',')(i)?;
 
     // 4. M = Magnetic
-    let (i, _) = preceded(char(','), char('M'))(i)?;
+    let (i, _) = char('M')(i)?;
+    let (i, _) = char(',')(i)?;
 
     // 5. Destination Waypoint
-    let (i, to_waypoint) = preceded(char(','), opt(is_not(",*")))(i)?;
+    let (i, to_waypoint) = opt(is_not(",*"))(i)?;
 
     // 6. origin Waypoint
     let from_waypoint = opt(preceded(char(','), is_not("*")))(i)?.1;


### PR DESCRIPTION
This PR introduces [`criterion`](https://github.com/bheisler/criterion.rs) as a dev-dependency to run benchmarks, instead of the nightly `bencher`.
The `gsv_parser` benchmark module now uses Criterion, and a new `nom_parsing` module has been added to compare parsing strategies for comma-separated values.
If we have `let sentence = "a,b";` the strategies are:
- the "discard comma" strategy already used in the crate:
  ```rust
  let (i, a) = char('a')(text)?;
  let (i, _) = char(',')(i)?; // the parsed comma is discarded with _
  let (i, b) = char('b')(i)?;
   ```
- the `preceded` combinator:
  ```rust
  let (i, a) = char('a')(text)?;
  let (i, b) = preceded(char(','), char('b'))(i)?;
  ```
Run `cargo bench` to run the benchmarks.

I initially thought that there would be significant performance improvement by using `preceded`, but it turns out that it's slightly slower. Therefore I also included an update of the parsing strategy for the BOD sentence (that I had previously worked on), to be like the other parsers in the crate and use the discard-comma strategy.