### PR TITLE
Unified handling text parameters

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -29,6 +29,9 @@ use crate::{sentences::*, Error, SentenceType};
 /// a 100-character PSTI message.
 pub const SENTENCE_MAX_LEN: usize = 102;
 
+/// Maximum length of a single waypoint id data in sentence
+pub const TEXT_PARAMETER_MAX_LEN: usize = 64;
+
 /// A known and parsable Nmea sentence type.
 pub struct NmeaSentence<'a> {
     pub talker_id: &'a str,

--- a/src/sentences/aam.rs
+++ b/src/sentences/aam.rs
@@ -1,3 +1,5 @@
+use crate::parse::TEXT_PARAMETER_MAX_LEN;
+
 use arrayvec::ArrayString;
 use nom::{
     bytes::complete::is_not,
@@ -7,8 +9,6 @@ use nom::{
 };
 
 use crate::{parse::NmeaSentence, sentences::utils::array_string, Error, SentenceType};
-
-const MAX_LEN: usize = 64;
 
 /// AAM - Waypoint Arrival Alarm
 ///
@@ -36,7 +36,7 @@ pub struct AamData {
     pub perpendicular_passed: Option<bool>,
     pub arrival_circle_radius: Option<f32>,
     pub radius_units: Option<char>,
-    pub waypoint_id: Option<ArrayString<MAX_LEN>>,
+    pub waypoint_id: Option<ArrayString<TEXT_PARAMETER_MAX_LEN>>,
 }
 
 /// Parse AAM message
@@ -81,7 +81,9 @@ fn do_parse_aam(i: &str) -> Result<AamData, Error> {
         perpendicular_passed,
         arrival_circle_radius,
         radius_units,
-        waypoint_id: waypoint_id.map(array_string::<MAX_LEN>).transpose()?,
+        waypoint_id: waypoint_id
+            .map(array_string::<TEXT_PARAMETER_MAX_LEN>)
+            .transpose()?,
     })
 }
 

--- a/src/sentences/bod.rs
+++ b/src/sentences/bod.rs
@@ -9,8 +9,6 @@ use nom::{
     sequence::preceded,
 };
 
-const MAX_LEN: usize = 64;
-
 /// BOD - Bearing - Waypoint to Waypoint
 ///
 /// <https://gpsd.gitlab.io/gpsd/NMEA.html#_bod_bearing_waypoint_to_waypoint>
@@ -24,8 +22,8 @@ const MAX_LEN: usize = 64;
 pub struct BodData {
     pub bearing_true: Option<f32>,
     pub bearing_magnetic: Option<f32>,
-    pub to_waypoint: Option<ArrayString<MAX_LEN>>,
-    pub from_waypoint: Option<ArrayString<MAX_LEN>>,
+    pub to_waypoint: Option<ArrayString<TEXT_PARAMETER_MAX_LEN>>,
+    pub from_waypoint: Option<ArrayString<TEXT_PARAMETER_MAX_LEN>>,
 }
 
 /// BOD - Bearing - Waypoint to Waypoint
@@ -63,8 +61,12 @@ fn do_parse_bod(i: &str) -> Result<BodData, Error> {
     Ok(BodData {
         bearing_true,
         bearing_magnetic,
-        to_waypoint: to_waypoint.map(array_string::<MAX_LEN>).transpose()?,
-        from_waypoint: from_waypoint.map(array_string::<MAX_LEN>).transpose()?,
+        to_waypoint: to_waypoint
+            .map(array_string::<TEXT_PARAMETER_MAX_LEN>)
+            .transpose()?,
+        from_waypoint: from_waypoint
+            .map(array_string::<TEXT_PARAMETER_MAX_LEN>)
+            .transpose()?,
     })
 }
 

--- a/src/sentences/bwc.rs
+++ b/src/sentences/bwc.rs
@@ -5,12 +5,10 @@ use nom::{
 };
 
 use crate::{
-    parse::NmeaSentence,
+    parse::{NmeaSentence, TEXT_PARAMETER_MAX_LEN},
     sentences::utils::{parse_hms, parse_lat_lon},
     Error, SentenceType,
 };
-
-const MAX_LEN: usize = 64;
 
 /// BWC - Bearing & Distance to Waypoint - Great Circle
 ///
@@ -30,7 +28,7 @@ pub struct BwcData {
     pub true_bearing: Option<f32>,
     pub magnetic_bearing: Option<f32>,
     pub distance: Option<f32>,
-    pub waypoint_id: Option<ArrayString<MAX_LEN>>,
+    pub waypoint_id: Option<ArrayString<TEXT_PARAMETER_MAX_LEN>>,
 }
 
 /// BWC - Bearing & Distance to Waypoint - Great Circle

--- a/src/sentences/txt.rs
+++ b/src/sentences/txt.rs
@@ -2,9 +2,10 @@ use arrayvec::ArrayString;
 use nom::{bytes::complete::take_while, character::complete::char, IResult};
 
 use super::utils::number;
-use crate::{parse::NmeaSentence, Error, SentenceType};
-
-const MAX_LEN: usize = 64;
+use crate::{
+    parse::{NmeaSentence, TEXT_PARAMETER_MAX_LEN},
+    Error, SentenceType,
+};
 
 /// Parse TXT message from u-blox device
 ///
@@ -24,7 +25,10 @@ pub fn parse_txt(s: NmeaSentence) -> Result<TxtData, Error> {
 
     let ret = do_parse_txt(s.data).map_err(Error::ParsingError)?.1;
 
-    let text = ArrayString::from(ret.text).map_err(|_e| Error::SentenceLength(ret.text.len()))?;
+    let text = ArrayString::from(ret.text).map_err(|_e| Error::ParameterLength {
+        max_length: TEXT_PARAMETER_MAX_LEN,
+        parameter_length: ret.text.len(),
+    })?;
 
     Ok(TxtData {
         count: ret.count,
@@ -64,7 +68,7 @@ pub struct TxtData {
     pub count: u8,
     pub seq: u8,
     pub text_ident: u8,
-    pub text: ArrayString<MAX_LEN>,
+    pub text: ArrayString<TEXT_PARAMETER_MAX_LEN>,
 }
 
 struct TxtData0<'a> {

--- a/src/sentences/utils.rs
+++ b/src/sentences/utils.rs
@@ -208,11 +208,14 @@ where
 ///
 /// # Errors
 ///
-/// If `&str` length > `MAX_LEN` it returns a [`Error::SentenceLength`] error.
+/// If `&str` length > `MAX_LEN` it returns a [`Error::ParameterLength`] error.
 pub(crate) fn array_string<const MAX_LEN: usize>(
     string: &str,
 ) -> Result<ArrayString<MAX_LEN>, Error> {
-    ArrayString::from(string).map_err(|_| Error::SentenceLength(string.len()))
+    ArrayString::from(string).map_err(|_| Error::ParameterLength {
+        max_length: MAX_LEN,
+        parameter_length: string.len(),
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
During experiments with c bindings for nmea library, found that multiple MAX_LEN consts are used around. All of the same value (64). This causes cbindgen to generate single const with ambiguous meaning.
When I look closer, found that I've used manual conversion waypoint ids to ArrayString, while proper array_string method is already done. This PR fixes this as well, and because array_string is used just for parameters, I've updated error with more proper one (ParameterLength).