### PR TITLE
fix clippy warnings

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -19,18 +19,18 @@ use crate::{sentences::*, Error, SentenceType};
 /// From `gpsd`:
 ///
 /// > We've had reports that on the Garmin GPS-10 the device sometimes
-/// (1:1000 or so) sends garbage packets that have a valid checksum
-/// but are like 2 successive NMEA packets merged together in one
-/// with some fields lost. Usually these are much longer than the
-/// legal limit for NMEA, so we can cope by just tossing out overlong
-/// packets.  This may be a generic bug of all Garmin chipsets.
-/// NMEA 3.01, Section 5.3 says the max sentence length shall be
-/// 82 chars, including the leading $ and terminating \r\n.
+/// > (1:1000 or so) sends garbage packets that have a valid checksum
+/// > but are like 2 successive NMEA packets merged together in one
+/// > with some fields lost. Usually these are much longer than the
+/// > legal limit for NMEA, so we can cope by just tossing out overlong
+/// > packets.  This may be a generic bug of all Garmin chipsets.
+/// > NMEA 3.01, Section 5.3 says the max sentence length shall be
+/// > 82 chars, including the leading $ and terminating \r\n.
 ///
 /// > Some receivers (TN-200, GSW 2.3.2) emit oversized sentences.
-/// The Trimble BX-960 receiver emits a 91-character GGA message.
-/// The current hog champion is the Skytraq S2525F8 which emits
-/// a 100-character PSTI message.
+/// > The Trimble BX-960 receiver emits a 91-character GGA message.
+/// > The current hog champion is the Skytraq S2525F8 which emits
+/// > a 100-character PSTI message.
 pub const SENTENCE_MAX_LEN: usize = 102;
 
 /// Maximum length of a single waypoint id data in sentence
@@ -53,7 +53,7 @@ impl<'a> NmeaSentence<'a> {
                 .as_bytes()
                 .iter()
                 .chain(self.message_id.as_str().as_bytes())
-                .chain(&[b','])
+                .chain(b",")
                 .chain(self.data.as_bytes()),
         )
     }

--- a/src/sentences/alm.rs
+++ b/src/sentences/alm.rs
@@ -32,6 +32,7 @@ use super::utils::number;
 ///  4. GPS Week Number (range 0 to 2^13 - 1), where:
 ///     - 0 is the week of the GPS Week Number epoch on January 6th 1980;
 ///     - 8191 is the week that precedes the next rollover on January 6th 2137;
+///
 ///     Note: the legacy representation started at the same epoch, but
 ///           the number is 10-bit wide only, with a rollover every 19.7 years.
 ///  6. Eccentricity

--- a/src/sentences/dbk.rs
+++ b/src/sentences/dbk.rs
@@ -111,7 +111,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1FF0.5,f,0405.5,M,0221.6,F*2E").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x2E);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1330.5,X,0405.5,M,0221.6,F*10").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x10);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -127,7 +127,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,04F5.5,M,0221.6,F*58").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x58);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,X,0221.6,F*3B").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x3B);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,M,02F1.6,F*5A").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x5A);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod tests {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,M,0221.6,X*30").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x30);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 
     #[test]
@@ -159,6 +159,6 @@ mod tests {
         let s = parse_nmea_sentence("$INMTW,17.9,x*20").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x20);
-        assert_eq!(true, parse_dbk(s).is_err());
+        assert!(parse_dbk(s).is_err());
     }
 }

--- a/src/sentences/mtw.rs
+++ b/src/sentences/mtw.rs
@@ -93,7 +93,7 @@ mod tests {
         let s = parse_nmea_sentence("$INMTW,17.9,x*20").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x20);
-        assert_eq!(true, parse_mtw(s).is_err());
+        assert!(parse_mtw(s).is_err());
     }
 
     #[test]
@@ -101,6 +101,6 @@ mod tests {
         let s = parse_nmea_sentence("$INMTW,x.9,C*65").unwrap();
         assert_eq!(s.checksum, s.calc_checksum());
         assert_eq!(s.checksum, 0x65);
-        assert_eq!(true, parse_mtw(s).is_err());
+        assert!(parse_mtw(s).is_err());
     }
 }

--- a/src/sentences/zda.rs
+++ b/src/sentences/zda.rs
@@ -252,12 +252,12 @@ mod tests {
         );
         assert_eq!(
             zda_data.offset(),
-            Some(FixedOffset::east_opt(-1 * 60 * 60).unwrap())
+            Some(FixedOffset::east_opt(-60 * 60).unwrap())
         );
         assert_eq!(
             zda_data.local_date_time(),
             Some(
-                FixedOffset::east_opt(-1 * 60 * 60)
+                FixedOffset::east_opt(-60 * 60)
                     .unwrap()
                     .from_local_datetime(&NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2004, 3, 11).unwrap(),

--- a/tests/file_log_parser.rs
+++ b/tests/file_log_parser.rs
@@ -16,7 +16,7 @@ fn test_parse_file_log() {
         .unwrap_or_else(|err| panic!("process file failed with error '{}'", err));
 
     let expected: Vec<_> = BufReader::new(
-        File::open(&Path::new("tests").join("data").join("nmea1.log.expected")).unwrap(),
+        File::open(Path::new("tests").join("data").join("nmea1.log.expected")).unwrap(),
     )
     .lines()
     .collect::<Result<_, _>>()
@@ -28,7 +28,7 @@ fn test_parse_file_log() {
 #[test]
 fn test_parse_issue_2() {
     let mut input =
-        BufReader::new(File::open(&Path::new("tests").join("data").join("nmea2.log")).unwrap());
+        BufReader::new(File::open(Path::new("tests").join("data").join("nmea2.log")).unwrap());
     let mut nmea = Nmea::default();
     for _ in 0..100 {
         let mut buffer = String::new();
@@ -58,7 +58,7 @@ fn test_parse_all_logs() {
     .enumerate()
     {
         println!("test parsing of {:?}", log_path);
-        let full_log = fs::read_to_string(&log_path).unwrap();
+        let full_log = fs::read_to_string(log_path).unwrap();
 
         let mut nmea1 = Nmea::default();
         let mut nmea2 = Nmea::default();


### PR DESCRIPTION
Currently main is failing when running `cargo clippy --no-deps -- -D warnings`. This PR fixes those errors.