### PR TITLE
Fix compilation error when printing `Error` with defmt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,9 @@ pub enum Error<'a> {
     /// An unknown [`GnssType`] was found in the NMEA message.
     UnknownGnssType(&'a str),
     /// The sentence could not be parsed because its format was invalid.
-    #[cfg_attr(feature = "defmt-03", defmt(defmt::Debug2Format))]
-    ParsingError(nom::Err<nom::error::Error<&'a str>>),
+    ParsingError(
+        #[cfg_attr(feature = "defmt-03", defmt(Debug2Format))] nom::Err<nom::error::Error<&'a str>>,
+    ),
     /// The sentence was too long to be parsed, our current limit is `SENTENCE_MAX_LEN` characters.
     SentenceLength(usize),
     /// Parameter was too long to fit into fixed ArrayString.


### PR DESCRIPTION
This fixes compilation errors like below:
```
error[E0277]: the trait bound `nom::internal::Err<nom::error::Error<&str>>: Format` is not satisfied
   --> nyan.rs:245:21
    |
245 |                     defmt::warn!("{:a}: {}", line, err);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Format` is not implemented for `nom::internal::Err<nom::error::Error<&str>>`
    |
    = help: the following other types implement trait `Format`:
              &T
              &mut T
              ()
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
              (T0, T1, T2, T3, T4, T5)
            and 234 others
    = note: required for `nmea::Error<'_>` to implement `Format`
note: required by a bound in `defmt::export::fmt`
```

The position of adding the `#[defmt()]` attribute seems to be wrong according to the [document](https://defmt.ferrous-systems.com/format#uncompressed-adapters). So I moved this inside the `ParsingError( ... )` and I verified it now compiles and works.